### PR TITLE
Force virtualbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.*.sw?
 .vagrant/
 *.box

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,14 +1,19 @@
 # -*- mode: ruby; -*-
+
+# Force Virtualbox for those people who have installed vagrant-lxc (e.g.)
+ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
+
 Vagrant.configure("2") do |config|
   config.vm.guest = :freebsd
-  config.vm.box_url = "http://files.wunki.org/freebsd-10.1-amd64-wunki.box"
-  config.vm.box = "freebsd-10.1-amd64-wunki"
   config.vm.network "private_network", ip: "10.0.1.10"
 
   # Use NFS as a shared folder
   config.vm.synced_folder ".", "/vagrant", :nfs => true, id: "vagrant-root"
 
-  config.vm.provider :virtualbox do |vb|
+  config.vm.provider :virtualbox do |vb, override|
+    override.vm.box_url = "http://files.wunki.org/freebsd-10.1-amd64-wunki.box"
+    override.vm.box = "freebsd-10.1-amd64-wunki"
+
     # vb.customize ["startvm", :id, "--type", "gui"]
     vb.customize ["modifyvm", :id, "--memory", "512"]
     vb.customize ["modifyvm", :id, "--cpus", "2"]


### PR DESCRIPTION
These changes guarantee that the provider will be Virtualbox and that a (more) useful error is thrown. 

Also, ignore VI swapfiles.